### PR TITLE
DO-299 Add support for UUID and Array to JDBC connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
             <version>${kafka.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.collections</groupId>
+            <artifactId>google-collections</artifactId>
+            <version>1.0</version>
+        </dependency>
 
          <!-- JDBC drivers, only included in runtime so they get packaged -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -123,11 +123,13 @@
             <groupId>com.mockrunner</groupId>
             <artifactId>mockrunner-jdbc</artifactId>
             <version>1.1.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20160810</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-jdbc</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.1-SNAPSHOT.blueapron.11</version>
+    <version>3.1.1-SNAPSHOT.blueapron.12</version>
     <name>kafka-connect-jdbc</name>
     <organization>
         <name>Confluent, Inc.</name>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <confluent.version>3.1.1-SNAPSHOT</confluent.version>
-        <kafka.version>0.10.1.0-SNAPSHOT</kafka.version>
+        <kafka.version>0.10.1.0</kafka.version>
         <junit.version>4.12</junit.version>
         <easymock.version>3.0</easymock.version>
         <powermock.version>1.6.2</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,17 @@
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.mockrunner/mockrunner-jdbc -->
+        <dependency>
+            <groupId>com.mockrunner</groupId>
+            <artifactId>mockrunner-jdbc</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20160810</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>google-collections</artifactId>
             <version>1.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20160810</version>
+        </dependency>
 
          <!-- JDBC drivers, only included in runtime so they get packaged -->
         <dependency>
@@ -128,12 +133,6 @@
             <groupId>com.mockrunner</groupId>
             <artifactId>mockrunner-jdbc</artifactId>
             <version>1.1.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20160810</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -66,7 +66,7 @@ public class BufferedRecords {
       final String insertSql = getInsertSql();
       log.debug("{} sql: {}", config.insertMode, insertSql);
       preparedStatement = connection.prepareStatement(insertSql);
-      preparedStatementBinder = new PreparedStatementBinder(preparedStatement, config.pkMode, schemaPair, fieldsMetadata);
+      preparedStatementBinder = new PreparedStatementBinder(preparedStatement, config.pkMode, schemaPair, fieldsMetadata, this.connection);
     }
 
     final List<SinkRecord> flushed;

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -28,8 +28,10 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.List;
 
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
 import io.confluent.connect.jdbc.sink.metadata.SchemaPair;
@@ -40,17 +42,20 @@ public class PreparedStatementBinder {
   private final PreparedStatement statement;
   private final SchemaPair schemaPair;
   private final FieldsMetadata fieldsMetadata;
+  private Connection connection;
 
   public PreparedStatementBinder(
       PreparedStatement statement,
       JdbcSinkConfig.PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
-      FieldsMetadata fieldsMetadata
+      FieldsMetadata fieldsMetadata,
+      Connection connection
   ) {
     this.pkMode = pkMode;
     this.statement = statement;
     this.schemaPair = schemaPair;
     this.fieldsMetadata = fieldsMetadata;
+    this.connection = connection;
   }
 
   public void bindRecord(SinkRecord record) throws SQLException {
@@ -106,10 +111,10 @@ public class PreparedStatementBinder {
   }
 
   void bindField(int index, Schema schema, Object value) throws SQLException {
-    bindField(statement, index, schema, value);
+    bindField(statement, index, schema, value, this.connection);
   }
 
-  static void bindField(PreparedStatement statement, int index, Schema schema, Object value) throws SQLException {
+  static void bindField(PreparedStatement statement, int index, Schema schema, Object value, Connection connection) throws SQLException {
     if (value == null) {
       statement.setObject(index, null);
     } else {
@@ -150,6 +155,10 @@ public class PreparedStatementBinder {
               bytes = (byte[]) value;
             }
             statement.setBytes(index, bytes);
+            break;
+          case ARRAY:
+            Object[] objects = ((List<String>) value).toArray();
+            statement.setArray(index, connection.createArrayOf("TEXT", objects));
             break;
           default:
             throw new ConnectException("Unsupported source data type: " + schema.type());

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -42,7 +42,7 @@ public class PreparedStatementBinder {
   private final PreparedStatement statement;
   private final SchemaPair schemaPair;
   private final FieldsMetadata fieldsMetadata;
-  private Connection connection;
+  private final Connection connection;
 
   public PreparedStatementBinder(
       PreparedStatement statement,

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
@@ -67,6 +67,8 @@ public class PostgreSqlDialect extends DbDialect {
         return "TEXT";
       case BYTES:
         return "BLOB";
+      case ARRAY:
+        return "text[]";
     }
     return super.getSqlType(schemaName, parameters, type);
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialect.java
@@ -68,7 +68,7 @@ public class PostgreSqlDialect extends DbDialect {
       case BYTES:
         return "BLOB";
       case ARRAY:
-        return "text[]";
+        return "TEXT[]";
     }
     return super.getSqlType(schemaName, parameters, type);
   }

--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -252,7 +252,6 @@ public class DataConverter {
       }
 
       case Types.ARRAY: {
-        // TODO - Right now we convert all arrays to arrays of strings, do we need to support other types yet?
         SchemaBuilder arrayBuilder = SchemaBuilder.array(
                 SchemaBuilder.STRING_SCHEMA
         );

--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -258,7 +258,7 @@ public class DataConverter {
         if (optional) {
           arrayBuilder.optional();
         }
-        builder.field(fieldName, arrayBuilder);
+        builder.field(fieldName, arrayBuilder.build());
         break;
       }
 

--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -252,15 +252,22 @@ public class DataConverter {
       case Types.OTHER: {
         // Some of these types will have fixed size, but we drop this from the schema conversion
         // since only fixed byte arrays can have a fixed size
-        String typeName = metadata.getColumnTypeName(col);
-        if (typeName.toLowerCase().equals("jsonb") || typeName.toLowerCase().equals("json")) {
-          if (optional) {
-            builder.field(fieldName, Schema.OPTIONAL_STRING_SCHEMA);
-          } else {
-            builder.field(fieldName, Schema.STRING_SCHEMA);
+        String typeName = metadata.getColumnTypeName(col).toLowerCase();
+        switch(typeName) {
+          case "jsonb":
+          case "json":
+          case "uuid": {
+            if (optional) {
+              builder.field(fieldName, Schema.OPTIONAL_STRING_SCHEMA);
+            } else {
+              builder.field(fieldName, Schema.STRING_SCHEMA);
+            }
+            break;
           }
-        } else {
-          log.warn("JDBC type {} ({}) not currently supported", sqlType, typeName);
+          default: {
+            log.warn("JDBC type {} ({}) not currently supported", sqlType, typeName);
+            break;
+          }
         }
         break;
       }
@@ -427,12 +434,19 @@ public class DataConverter {
       }
 
       case Types.OTHER: {
-        if (typeName.toLowerCase().equals("jsonb") || typeName.toLowerCase().equals("json")) {
-          colValue = resultSet.getString(col);
-          break;
-        } else {
-          return;
+        String type = typeName.toLowerCase().toLowerCase();
+        switch(type) {
+          case "jsonb":
+          case "json":
+          case "uuid": {
+            colValue = resultSet.getString(col);
+            break;
+          }
+          default: {
+            return;
+          }
         }
+        break;
       }
 
       case Types.ARRAY:

--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -454,6 +454,7 @@ public class DataConverter {
           if (obj == null) {
             stringArray.add(null);
           } else if (String.class.isAssignableFrom(obj.getClass()) || JSONObject.class.isAssignableFrom(obj.getClass())) {
+            // json.org.JSONObject guarantees that toString will conform to JSON syntax rules (https://stleary.github.io/JSON-java/)
             stringArray.add(obj.toString());
           } else {
             throw new IOException("Can't process input, supported types in arrays are string, JSON, and null. Your type: " + obj.getClass());

--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -37,7 +37,10 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Types;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 
 /**
@@ -447,7 +450,7 @@ public class DataConverter {
         Array arr = resultSet.getArray(col);
 
         // https://docs.oracle.com/javase/tutorial/jdbc/basics/array.html#retrieving_array
-        Object[] objectArray = (Object[])arr.getArray();
+        Object[] objectArray = (Object[]) arr.getArray();
 
         // The schema validator actually expects a list, not an array
         // For now, convert all types in the array to Strings

--- a/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/DataConverter.java
@@ -37,10 +37,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.TimeZone;
+import java.util.*;
 
 
 /**
@@ -449,14 +446,17 @@ public class DataConverter {
       case Types.ARRAY: {
         Array arr = resultSet.getArray(col);
 
-        // For right now, cast all values in the array to Strings
-        ArrayList<String> convertedList = new ArrayList<>();
-        int currentRow = 1;
-        while (arr.getResultSet().next()) {
-          convertedList.add(arr.getResultSet().getString(currentRow));
-          currentRow += 1;
+        // https://docs.oracle.com/javase/tutorial/jdbc/basics/array.html#retrieving_array
+        Object[] objectArray = (Object[])arr.getArray();
+
+        // The schema validator actually expects a list, not an array
+        // For now, convert all types in the array to Strings
+        ArrayList<String> stringArray = new ArrayList<>();
+        for (Object obj: objectArray) {
+          stringArray.add(obj.toString());
         }
-        colValue = convertedList.toArray();
+
+        colValue = stringArray;
         break;
       }
 

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
@@ -54,7 +54,7 @@ public class PostgreSqlDialectTest extends BaseDialectTest {
     verifyDataTypeMapping("DATE", Date.SCHEMA);
     verifyDataTypeMapping("TIME", Time.SCHEMA);
     verifyDataTypeMapping("TIMESTAMP", Timestamp.SCHEMA);
-    verifyDataTypeMapping("text[]", arrayBuilder.build());
+    verifyDataTypeMapping("TEXT[]", arrayBuilder.build());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/dialect/PostgreSqlDialectTest.java
@@ -19,6 +19,7 @@ package io.confluent.connect.jdbc.sink.dialect;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
@@ -36,6 +37,10 @@ public class PostgreSqlDialectTest extends BaseDialectTest {
 
   @Test
   public void dataTypeMappings() {
+    SchemaBuilder arrayBuilder = SchemaBuilder.array(
+        SchemaBuilder.STRING_SCHEMA
+    );
+
     verifyDataTypeMapping("SMALLINT", Schema.INT8_SCHEMA);
     verifyDataTypeMapping("SMALLINT", Schema.INT16_SCHEMA);
     verifyDataTypeMapping("INT", Schema.INT32_SCHEMA);
@@ -49,6 +54,7 @@ public class PostgreSqlDialectTest extends BaseDialectTest {
     verifyDataTypeMapping("DATE", Date.SCHEMA);
     verifyDataTypeMapping("TIME", Time.SCHEMA);
     verifyDataTypeMapping("TIMESTAMP", Timestamp.SCHEMA);
+    verifyDataTypeMapping("text[]", arrayBuilder.build());
   }
 
   @Test

--- a/src/test/java/io/confluent/connect/jdbc/source/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/DataConverterTest.java
@@ -1,0 +1,67 @@
+package io.confluent.connect.jdbc.source;
+
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import javax.sql.rowset.RowSetMetaDataImpl;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
+
+public class DataConverterTest {
+
+    @Test
+    public void convertsJSONToString() throws SQLException {
+        final String tableName = "test";
+        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
+        rowSetMetaData.setColumnCount(1);
+        rowSetMetaData.setColumnType(1, Types.OTHER);
+        rowSetMetaData.setColumnTypeName(1, "JSON");
+        final ResultSetMetaData metaData = rowSetMetaData;
+        Schema schema = DataConverter.convertSchema(tableName, metaData);
+        assertEquals(schema.fields().size(), 1);
+        assertEquals("Expected JSON to be converted to a string", Schema.Type.STRING, schema.fields().get(0).schema().type());
+    }
+
+    @Test
+    public void convertsJSONBToString() throws SQLException {
+        final String tableName = "test";
+        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
+        rowSetMetaData.setColumnCount(1);
+        rowSetMetaData.setColumnType(1, Types.OTHER);
+        rowSetMetaData.setColumnTypeName(1, "JSONB");
+        final ResultSetMetaData metaData = rowSetMetaData;
+        Schema schema = DataConverter.convertSchema(tableName, metaData);
+        assertEquals(schema.fields().size(), 1);
+        assertEquals("Expected JSONB to be converted to a string", Schema.Type.STRING, schema.fields().get(0).schema().type());
+    }
+
+    @Test
+    public void convertsUUIDToString() throws SQLException {
+        final String tableName = "test";
+        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
+        rowSetMetaData.setColumnCount(1);
+        rowSetMetaData.setColumnType(1, Types.OTHER);
+        rowSetMetaData.setColumnTypeName(1, "UUID");
+        final ResultSetMetaData metaData = rowSetMetaData;
+        Schema schema = DataConverter.convertSchema(tableName, metaData);
+        assertEquals(schema.fields().size(), 1);
+        assertEquals("Expected UUID to be converted to a string", Schema.Type.STRING, schema.fields().get(0).schema().type());
+    }
+
+    @Test
+    public void supportsArrayType() throws SQLException {
+        final String tableName = "test";
+        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
+        rowSetMetaData.setColumnCount(1);
+        rowSetMetaData.setColumnType(1, Types.ARRAY);
+        rowSetMetaData.setColumnTypeName(1, "ARRAY");
+        final ResultSetMetaData metaData = rowSetMetaData;
+        Schema schema = DataConverter.convertSchema(tableName, metaData);
+        assertEquals(schema.fields().size(), 1);
+        assertEquals("Expected Array to be supported", Schema.Type.ARRAY, schema.fields().get(0).schema().type());
+    }
+}

--- a/src/test/java/io/confluent/connect/jdbc/source/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/DataConverterTest.java
@@ -1,67 +1,191 @@
 package io.confluent.connect.jdbc.source;
 
 
+import com.mockrunner.mock.jdbc.MockArray;
+import com.mockrunner.mock.jdbc.MockConnection;
+import com.mockrunner.mock.jdbc.MockResultSet;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.json.JSONObject;
 import org.junit.Test;
-
+import org.mockito.Mockito;
 import javax.sql.rowset.RowSetMetaDataImpl;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Types;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 
 public class DataConverterTest {
 
-    @Test
-    public void convertsJSONToString() throws SQLException {
-        final String tableName = "test";
+    /**
+     * Helpers
+     */
+    private ResultSetMetaData createJSONMetadata() throws SQLException {
         RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
         rowSetMetaData.setColumnCount(1);
-        rowSetMetaData.setColumnType(1, Types.OTHER);
-        rowSetMetaData.setColumnTypeName(1, "JSON");
-        final ResultSetMetaData metaData = rowSetMetaData;
+        int columnIndex = 1;
+        rowSetMetaData.setColumnType(columnIndex, Types.OTHER);
+        rowSetMetaData.setColumnTypeName(columnIndex, "JSON");
+        rowSetMetaData.setColumnLabel(columnIndex, "json_column");
+        return rowSetMetaData;
+    }
+
+    private ResultSetMetaData createJSONBMetadata() throws SQLException {
+        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
+        rowSetMetaData.setColumnCount(1);
+        int columnIndex = 1;
+        rowSetMetaData.setColumnType(columnIndex, Types.OTHER);
+        rowSetMetaData.setColumnTypeName(columnIndex, "JSONB");
+        rowSetMetaData.setColumnLabel(columnIndex, "jsonb_column");
+        return rowSetMetaData;
+    }
+
+    private ResultSetMetaData createUUIDMetadata() throws SQLException {
+        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
+        rowSetMetaData.setColumnCount(1);
+        int columnIndex = 1;
+        rowSetMetaData.setColumnType(columnIndex, Types.OTHER);
+        rowSetMetaData.setColumnTypeName(columnIndex, "UUID");
+        rowSetMetaData.setColumnLabel(columnIndex, "uuid_column");
+        return rowSetMetaData;
+    }
+
+    private ResultSetMetaData createArrayMetadata() throws SQLException {
+        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
+        rowSetMetaData.setColumnCount(1);
+        int columnIndex = 1;
+        rowSetMetaData.setColumnType(columnIndex, Types.ARRAY);
+        rowSetMetaData.setColumnTypeName(columnIndex, "ARRAY");
+        rowSetMetaData.setColumnLabel(columnIndex, "array_column");
+        return rowSetMetaData;
+    }
+
+    /**
+     * Schema conversion tests
+     */
+    @Test
+    public void convertsJSONSchemaToString() throws SQLException {
+        final String tableName = "test";
+        final ResultSetMetaData metaData = createJSONMetadata();
         Schema schema = DataConverter.convertSchema(tableName, metaData);
         assertEquals(schema.fields().size(), 1);
         assertEquals("Expected JSON to be converted to a string", Schema.Type.STRING, schema.fields().get(0).schema().type());
     }
 
     @Test
-    public void convertsJSONBToString() throws SQLException {
+    public void convertsJSONBSchemaToString() throws SQLException {
         final String tableName = "test";
-        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
-        rowSetMetaData.setColumnCount(1);
-        rowSetMetaData.setColumnType(1, Types.OTHER);
-        rowSetMetaData.setColumnTypeName(1, "JSONB");
-        final ResultSetMetaData metaData = rowSetMetaData;
+        final ResultSetMetaData metaData = createJSONBMetadata();
         Schema schema = DataConverter.convertSchema(tableName, metaData);
         assertEquals(schema.fields().size(), 1);
         assertEquals("Expected JSONB to be converted to a string", Schema.Type.STRING, schema.fields().get(0).schema().type());
     }
 
     @Test
-    public void convertsUUIDToString() throws SQLException {
+    public void convertsUUIDSchemaToString() throws SQLException {
         final String tableName = "test";
-        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
-        rowSetMetaData.setColumnCount(1);
-        rowSetMetaData.setColumnType(1, Types.OTHER);
-        rowSetMetaData.setColumnTypeName(1, "UUID");
-        final ResultSetMetaData metaData = rowSetMetaData;
+        final ResultSetMetaData metaData = createUUIDMetadata();
         Schema schema = DataConverter.convertSchema(tableName, metaData);
         assertEquals(schema.fields().size(), 1);
         assertEquals("Expected UUID to be converted to a string", Schema.Type.STRING, schema.fields().get(0).schema().type());
     }
 
     @Test
-    public void supportsArrayType() throws SQLException {
+    public void supportsArraySchemaType() throws SQLException {
         final String tableName = "test";
-        RowSetMetaDataImpl rowSetMetaData = new RowSetMetaDataImpl();
-        rowSetMetaData.setColumnCount(1);
-        rowSetMetaData.setColumnType(1, Types.ARRAY);
-        rowSetMetaData.setColumnTypeName(1, "ARRAY");
-        final ResultSetMetaData metaData = rowSetMetaData;
+        final ResultSetMetaData metaData = createArrayMetadata();
         Schema schema = DataConverter.convertSchema(tableName, metaData);
         assertEquals(schema.fields().size(), 1);
         assertEquals("Expected Array to be supported", Schema.Type.ARRAY, schema.fields().get(0).schema().type());
+    }
+
+    /**
+     * Field value conversion tests
+     */
+    @Test
+    public void convertsJSONValueToString() throws SQLException {
+        final String tableName = "test";
+        final String jsonString = "{\"bar\":\"baz\",\"balance\":7.77,\"active\":false}";
+        final ResultSetMetaData metaData = createJSONMetadata();
+        Schema schema = DataConverter.convertSchema(tableName, metaData);
+
+        MockResultSet mockResultSet = new MockResultSet("myResults");
+        mockResultSet.addColumn("json_column");
+        mockResultSet.setResultSetMetaData(metaData);
+        mockResultSet.addRow(new Object[] { new JSONObject(jsonString) });
+
+        // Point the cursor at the first row
+        mockResultSet.next();
+
+        Struct record = DataConverter.convertRecord(schema, mockResultSet);
+
+        assertEquals("Expected JSON to match JSON string", jsonString, record.get("json_column"));
+    }
+
+    @Test
+    public void convertsJSONBValueToString() throws SQLException {
+        final String tableName = "test";
+        final String jsonbString = "{\"bar\":\"baz\",\"balance\":7.77,\"active\":false}";
+        final ResultSetMetaData metaData = createJSONBMetadata();
+        Schema schema = DataConverter.convertSchema(tableName, metaData);
+
+        MockResultSet mockResultSet = new MockResultSet("myResults");
+        mockResultSet.addColumn("jsonb_column");
+        mockResultSet.setResultSetMetaData(metaData);
+        mockResultSet.addRow(new Object[] {new JSONObject(jsonbString)});
+
+        // Point the cursor at the first row
+        mockResultSet.next();
+
+        Struct record = DataConverter.convertRecord(schema, mockResultSet);
+
+        assertEquals("Expected JSONB to match JSONB string", jsonbString, record.get("jsonb_column"));
+    }
+
+    @Test
+    public void convertsUUIDValueToString() throws SQLException {
+        final String tableName = "test";
+        final String uuidString = "123e4567-e89b-12d3-a456-426655440000";
+        final ResultSetMetaData metaData = createUUIDMetadata();
+        Schema schema = DataConverter.convertSchema(tableName, metaData);
+
+        MockResultSet mockResultSet = new MockResultSet("myResults");
+        mockResultSet.addColumn("uuid_column");
+        mockResultSet.setResultSetMetaData(metaData);
+        mockResultSet.addRow(new Object[] { UUID.fromString(uuidString) });
+
+        // Point the cursor at the first row
+        mockResultSet.next();
+
+        Struct record = DataConverter.convertRecord(schema, mockResultSet);
+
+        assertEquals("Expected UUID to match UUID string", uuidString, record.get("uuid_column"));
+    }
+
+    @Test
+    public void supportsArrayValue() throws SQLException {
+        // Setup
+        final String tableName = "test";
+        final ResultSetMetaData metaData = createArrayMetadata();
+        Schema schema = DataConverter.convertSchema(tableName, metaData);
+
+        MockResultSet mockResultSet = new MockResultSet("myResults");
+        mockResultSet.addColumn("array_column");
+        mockResultSet.setResultSetMetaData(metaData);
+
+        // Create a fake connection so that we can create an Array
+        Connection con = new MockConnection();
+        Array numbersArray = con.createArrayOf("STRING", new Object[]{"1", "2", "3"});
+        mockResultSet.addRow(new Object[]{numbersArray});
+
+        // Point the cursor at the first row
+        mockResultSet.next();
+
+        Struct record = DataConverter.convertRecord(schema, mockResultSet);
+        assertEquals(schema.fields().size(), 1);
+        assertEquals("Expected JSON to be converted to a string", Schema.Type.STRING, schema.fields().get(0).schema().type());
     }
 }

--- a/src/test/java/io/confluent/connect/jdbc/source/DataConverterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/DataConverterTest.java
@@ -178,14 +178,40 @@ public class DataConverterTest {
 
         // Create a fake connection so that we can create an Array
         Connection con = new MockConnection();
-        Array numbersArray = con.createArrayOf("STRING", new Object[]{"1", "2", "3"});
+        Object[] testArray = new Object[]{"1", "2", "3"};
+        Array numbersArray = con.createArrayOf("STRING", testArray);
         mockResultSet.addRow(new Object[]{numbersArray});
 
         // Point the cursor at the first row
         mockResultSet.next();
 
         Struct record = DataConverter.convertRecord(schema, mockResultSet);
-        assertEquals(schema.fields().size(), 1);
-        assertEquals("Expected JSON to be converted to a string", Schema.Type.STRING, schema.fields().get(0).schema().type());
+        List<String> expectedResult = Arrays.asList("1", "2", "3");
+        assertEquals("Expected Array to match Array of Strings", expectedResult, record.get("array_column"));
+    }
+
+    @Test
+    public void convertsNonStringArrayValuesToStringArrayValues() throws SQLException {
+        // Setup
+        final String tableName = "test";
+        final ResultSetMetaData metaData = createArrayMetadata();
+        Schema schema = DataConverter.convertSchema(tableName, metaData);
+
+        MockResultSet mockResultSet = new MockResultSet("myResults");
+        mockResultSet.addColumn("array_column");
+        mockResultSet.setResultSetMetaData(metaData);
+
+        // Create a fake connection so that we can create an Array
+        Connection con = new MockConnection();
+        Object[] testArray = new Object[]{1, 2, 3};
+        Array numbersArray = con.createArrayOf("STRING", testArray);
+        mockResultSet.addRow(new Object[]{numbersArray});
+
+        // Point the cursor at the first row
+        mockResultSet.next();
+
+        Struct record = DataConverter.convertRecord(schema, mockResultSet);
+        List<String> expectedResult = Arrays.asList("1", "2", "3");
+        assertEquals("Expected Array to match Array of Strings", expectedResult, record.get("array_column"));
     }
 }


### PR DESCRIPTION
Summary
---------
This change enables support for UUIDs and arrays by converting UUIDs to strings and arrays to arrays of strings.

It also adds support for the array type to the Postgres sink so that the change could be tested locally.

Test Strategy
-------------
Changes to the DataConverter and Postgres dialect were tested with unit tests.

The whole change was tested by setting up the development environment specified here: https://portal.blueapron.com/display/BA/Kafka+Connect as well as Kafka Connect UI and creating a Postgres source and Postgres sink. A table with a small amount of data was created in Postgres that the source pulled from and we validated that a new table with the translated data was created and populated by the sink.

@mraimi @samuelchase @jasonjho @willyhoang Mind taking a look?