### PR TITLE
Add distribution management to the `pom` file for deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
         <tag>HEAD</tag>
     </scm>
 
+    <distributionManagement>
+        <repository>
+            <id>nexus</id>
+            <url>http://ec2-54-210-98-107.compute-1.amazonaws.com:8081/repository/maven-releases/</url>
+        </repository>
+    </distributionManagement>
+
     <properties>
         <confluent.version>3.1.1-SNAPSHOT</confluent.version>
         <kafka.version>0.10.1.0</kafka.version>


### PR DESCRIPTION
Re-adding the distributionManagement section to the `pom.xml` file so that we can deploy the jar to nexus.

@willyhoang Mind taking a look?